### PR TITLE
Set default max_wal_senders to 10

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 wal2json_build_from_source: false
 
-wal2json_max_wal_senders: 1
+wal2json_max_wal_senders: 10
 wal2json_max_replication_slots: 1
 wal2json_set_preload_libraries: true
 


### PR DESCRIPTION
This is actually the postgres default. Also; setting it to 1 can cause issues even if only one slot is being used; if the slot encounters a problem it can block the creation of a new/restarted slot.