### PR TITLE
Set default max_replication_slots to 10

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 wal2json_build_from_source: false
 
 wal2json_max_wal_senders: 10
-wal2json_max_replication_slots: 1
+wal2json_max_replication_slots: 10
 wal2json_set_preload_libraries: true
 
 wal2json_path: "/usr/local/src/wal2json/"


### PR DESCRIPTION
This is in line with the postgres default.